### PR TITLE
corrected typo

### DIFF
--- a/sty/register.py
+++ b/sty/register.py
@@ -132,7 +132,7 @@ class RsRegister(Register):
         self.fg = Style(Sgr(39))
         self.bg = Style(Sgr(49))
         # Reset all effects (Unfortunately there is no single Escape Sequence for this)
-        self.rs = Style(Sgr(22), Sgr(23), Sgr(24), Sgr(25), Sgr(27), Sgr(28), Sgr(29))
+        self.ef = Style(Sgr(22), Sgr(23), Sgr(24), Sgr(25), Sgr(27), Sgr(28), Sgr(29))
 
         self.bold_dim = Style(Sgr(22))
         self.dim_bold = Style(Sgr(22))


### PR DESCRIPTION
I assume it's intended that rs.ef (reset.effects) would reset effects, rather than rs.rs (reset.reset), which implies resetting all, despite there already existing rs.all.

Nice library.  I like your API, it concisely expresses intent using the minimum of keystrokes.