### PR TITLE
Include py.typed file to mark package as typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[],
     packages=find_packages(where=".", exclude=("tests", "tests.*")),
     package_dir={"sty": "sty"},
-    package_data={},
+    package_data={"sty": ["py.typed"]},
     data_files=[],
     entry_points={"console_scripts": [], "gui_scripts": []},
     tests_require=[],


### PR DESCRIPTION
When using sty in another file and type-checking with `mypy`, I get:

```
src/new.py:9: error: Skipping analyzing "sty": module is installed, but missing library stubs or py.typed marker  [import]
src/new.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

So I added a `py.typed` marker file and included it in `setup.py` according to [PEP 561](https://peps.python.org/pep-0561/) to mark this as typed (which it is). This should let mypy correctly use the type annotations if I'm not mistaken.